### PR TITLE
Allow all approves

### DIFF
--- a/contracts/MiniMeToken.sol
+++ b/contracts/MiniMeToken.sol
@@ -210,19 +210,21 @@ contract MiniMeToken is Controlled {
     }
 
     /// @notice `msg.sender` approves `_spender` to spend `_amount` tokens on
-    ///  its behalf. This is a modified version of the ERC20 approve function
-    ///  to be a little bit safer
+    ///  its behalf.
+
     /// @param _spender The address of the account able to transfer the tokens
     /// @param _amount The amount of tokens to be approved for transfer
     /// @return True if the approval was successful
     function approve(address _spender, uint256 _amount) public returns (bool success) {
         require(transfersEnabled);
-
-        // To change the approve amount you first have to reduce the addresses`
+        
+        //  To change the approve amount you first have to reduce the addresses`
         //  allowance to zero by calling `approve(_spender,0)` if it is not
         //  already 0 to mitigate the race condition described here:
         //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-        require((_amount == 0) || (allowed[msg.sender][_spender] == 0));
+        //  According to the ERC20 standard, the interface has to deal with the issue,
+        //  but the contract must still accept all approves for backward compatibility.
+
 
         // Alerts the token controller of the approve function call
         if (isContract(controller)) {


### PR DESCRIPTION
The approve function should not revert if it approves a non 0 value, even if it's already non 0. The ERC20 standard states that the interface should prevent it, not the contract.
"NOTE: To prevent attack vectors like the one described here and discussed here, clients SHOULD make sure to create user interfaces in such a way that they set the allowance first to 0 before setting it to another value for the same spender. THOUGH The contract itself shouldn't enforce it, to allow backwards compatibility with contracts deployed before"
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md

This PR follows this issue: https://github.com/Giveth/minime/issues/45