### PR TITLE
Fixed typo

### DIFF
--- a/contracts/MiniMeToken.sol
+++ b/contracts/MiniMeToken.sol
@@ -168,7 +168,7 @@ contract MiniMeToken is Controlled {
     ) internal {
 
            if (_amount == 0) {
-               Transfer(_from, _to, _amount);    // Follow the spec to louch the event when transfer 0
+               Transfer(_from, _to, _amount);    // Follow the spec to launch the event when transfer 0
                return;
            }
 


### PR DESCRIPTION
By the way, is there a reason why transferring 0 should be treated independently?
What prevents it from fitting in the general case?