### PR TITLE
Add Solidity syntax highlight

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sol linguist-language=Solidity
+


### PR DESCRIPTION
GitHub doesn’t support automatically detecting .sol files as Solidity for syntax highlighting.

Adding this `.gitattributes` file to your repo’s root will fix this problem, and .sol files in `contracts/` will be nicer to read from Github.