### PR TITLE
msg.data length check in MiniMeToken#fallback

### DIFF
--- a/contracts/MiniMeToken.sol
+++ b/contracts/MiniMeToken.sol
@@ -482,6 +482,7 @@ contract MiniMeToken is Controlled {
     ///  set to 0, then the `proxyPayment` method is called which relays the
     ///  ether and creates tokens as described in the token controller contract
     function () public payable {
+        require(msg.data.length == 0);
         require(isContract(controller));
         require(TokenController(controller).proxyPayment.value(msg.value)(msg.sender));
     }


### PR DESCRIPTION
[MiniMeToken#fallback](https://github.com/Giveth/minime/blob/ea04d95/contracts/MiniMeToken.sol#L484-L487) can also be called when function signature is not matched. This is not assumed in the implementation of the fallback function, which always calls `TokenController#proxyPayment`. It should check `msg.data.length` to differentiate intentional proxy payment from unintentional function calls (signature mismatch).